### PR TITLE
Pt#116136759 error attaching audit image and #116135959 Audit signature fields are cleared on submit if not all required fields are filled.

### DIFF
--- a/app/models/formbuilder/response_field_file.rb
+++ b/app/models/formbuilder/response_field_file.rb
@@ -19,12 +19,12 @@ module Formbuilder
     end
 
     def render_input(value, opts = {})
-      entry_attachment = Formbuilder::EntryAttachment.find_by_id(value)
+      entry_attachment = get_attachments(value).first
       upload = entry_attachment.try(:upload)
       remote_upload_url = entry_attachment.try(:remote_upload_url)
       """
-        <span class='existing-filename'>#{get_attachments(value).first.try(:upload).try(:raw_filename)}</span>
-        <input type='file' name='response_fields[#{self[:id]}][]' id='response_fields_#{self[:id]}' value='#{upload}' />
+        <span class='existing-filename' style='cursor: default;'>#{upload}</span>
+        <input type='file' name='response_fields[#{self[:id]}][]' id='response_fields_#{self[:id]}'' />
         <input type='hidden' name='response_fields[#{self[:id]}][]' id='response_fields_#{self[:id]}_buffer' class='file-buffer' value='#{remote_upload_url}' />
       """
     end

--- a/app/models/formbuilder/response_field_file.rb
+++ b/app/models/formbuilder/response_field_file.rb
@@ -19,9 +19,13 @@ module Formbuilder
     end
 
     def render_input(value, opts = {})
+      entry_attachment = Formbuilder::EntryAttachment.find_by_id(value)
+      upload = entry_attachment.try(:upload)
+      remote_upload_url = entry_attachment.try(:remote_upload_url)
       """
         <span class='existing-filename'>#{get_attachments(value).first.try(:upload).try(:raw_filename)}</span>
-        <input type='file' name='response_fields[#{self[:id]}][]' id='response_fields_#{self[:id]}' />
+        <input type='file' name='response_fields[#{self[:id]}][]' id='response_fields_#{self[:id]}' value='#{upload}' />
+        <input type='hidden' name='response_fields[#{self[:id]}][]' id='response_fields_#{self[:id]}_buffer' class='file-buffer' value='#{remote_upload_url}' />
       """
     end
 

--- a/app/models/formbuilder/response_field_signature.rb
+++ b/app/models/formbuilder/response_field_signature.rb
@@ -12,19 +12,29 @@ module Formbuilder
 
       str = """
         <div id='signature-pad-#{self.id}' class='m-signature-pad'>
-          <div class='m-signature-pad--body'>
-            <canvas data-id='#{self.id}'></canvas>
-          </div>
-          <div class='m-signature-pad--footer'>
-            <div class='description'>#{self[:field_options][:description]}</div>
-            <button type='button' class='button clear' data-clear-id='#{self.id}' data-action='clear'>Clear</button>
-            <button type='button' class='button save' data-save-id='#{self.id}' data-action='save'>Save</button>
-          </div>
+      """
+      if value.present?
+        str += """
+        <img src='#{value}'>
+        """
+      else
+        str += """
+        <div class='m-signature-pad--body'>
+          <canvas data-id='#{self.id}'></canvas>
+        </div>
+        <div class='m-signature-pad--footer'>
+          <div class='description'>#{self[:field_options][:description]}</div>
+          <button type='button' class='button clear' data-clear-id='#{self.id}' data-action='clear'>Clear</button>
+          <button type='button' class='button save' data-save-id='#{self.id}' data-action='save'>Save</button>
+        </div>
+        """
+      end
+      str += """
         </div>
       """
 
       str += """
-        <input name='response_fields[#{self.id}]' type='hidden' value='' />
+        <input name='response_fields[#{self.id}]' type='hidden' value='#{value}' />
       """
 
       str


### PR DESCRIPTION
This pull request addresses similar issues in 
PT#116136759 error attaching audit image 
https://www.pivotaltracker.com/story/show/116136759
and 
PT#116135959 Audit signature fields are cleared on submit if not all required fields are filled
https://www.pivotaltracker.com/story/show/116135959.

Mainly, the ability to remember file and signature fields on re-submit when validation fails.

Reviewer Checklist:
- [x] PT#116136759 Added file upload hidden field to remember value on re-submit (e.g. failed validation)
- [x] PT#116136759 Ensured initializing file upload field with submitted URL and file name if exists (e.g. failed validation resubmit)
- [x] PT#116135959 Ensured initializing signature field with submitted signature image if exists (e.g. failed validation resubmit)