### PR TITLE
Added support for specifying rendering format and pdf embedded images

### DIFF
--- a/app/models/formbuilder/response_field_file.rb
+++ b/app/models/formbuilder/response_field_file.rb
@@ -39,7 +39,7 @@ module Formbuilder
           """
 
           str << """
-            <img src='#{attachment.remote_upload_url('thumb')}' /><br />
+          <img src='#{thumb_url(attachment, opts[:format])}' /><br />
           """
 
           str << """
@@ -56,6 +56,15 @@ module Formbuilder
       get_attachments(value).map { |attachment|
         attachment.remote_upload_url
       }.join(', ')
+    end
+
+    def thumb_url(attachment, format)
+      if format.to_s == 'pdf'
+        thumb = attachment.remote_upload_image('thumb')
+        thumb_url = "data:image/#{attachment.extension};base64,#{thumb}"
+      else
+        thumb_url = attachment.remote_upload_url('thumb')
+      end
     end
 
     def audit_response(value, all_responses)

--- a/lib/formbuilder/views/entry_dl.rb
+++ b/lib/formbuilder/views/entry_dl.rb
@@ -2,10 +2,13 @@ module Formbuilder
   module Views
     class EntryDl < Erector::Widget
 
+      self.ignore_extra_assigns = true
+
       needs :entry,
             :form,
             show_blind: false,
             show_admin_only: false
+
 
       def content
         dl(class: 'entry-dl') {
@@ -19,7 +22,7 @@ module Formbuilder
             }
 
             dd {
-              if (x = rf.render_entry(value, entry: @entry))
+              if (x = rf.render_entry(value, entry: @entry, format: @format))
                 rawtext x
               else
                 no_response


### PR DESCRIPTION
Look for matching PRs in Buccaneer and Scheduler
https://github.com/kbslabs/scheduler/pull/304
https://github.com/kbslabs/buccaneer/pull/36

- [x] Ability to pass :format as EntryDl erector widget
- [x] EntryAttachment#extension for image extension
- [x] EntryAttachment#remote_upload_image to download image binary
- [x] Supporting PDF format in rendering image file by embedding base64 encoded image tag