### PR TITLE
Decode images before creating s3 link as it re-encodes spaces

### DIFF
--- a/app/models/formbuilder/entry_attachment.rb
+++ b/app/models/formbuilder/entry_attachment.rb
@@ -11,7 +11,7 @@ module Formbuilder
       else
         directory = directory.sub('originals', version.pluralize)
       end
-      AWS_BUCKET.object(File.join(directory, file)).presigned_url(:get)
+      AWS_BUCKET.object(File.join(directory, URI.decode(file))).presigned_url(:get)
     end
 
     def remote_upload_image(version='original')


### PR DESCRIPTION
This fixes this issue: https://www.pivotaltracker.com/story/show/117203965

Audit image file names don't match S3 key. 

uploads/originals/1459954418992/response_fields_11662-1459954419130/2016-04-06%252525252525252525252525252011.00.46.jpg